### PR TITLE
Remove project card when removed from team Zube board

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "command": "yarn dev",
+            "name": "Run npm start",
+            "request": "launch",
+            "type": "node-terminal"
+        }
+    ]
+}

--- a/card-created.js
+++ b/card-created.js
@@ -38,18 +38,22 @@ module.exports = async function onCardCreated(context) {
     } = issue;
     const zubeLabel = labels.find((l) => l.name.includes('[zube]'));
     if (zubeLabel) {
-      const { nodes: columns } = await getColumnsByProjectName({
-        context,
-        repoId,
-        projectName: column.project.name,
-      });
-      // issue already has a Zube label, move to matching projects column
-      await moveProjectCard({
-        context,
-        projectCardNode,
-        newColumn: zubeLabel.name,
-        projectColumns: columns,
-      });
+      if (zubeLabel.name.toLowerCase() === `[zube]: ${column.name.toLowerCase()}`) {
+        // do nothing if column is the same as the label
+      } else {
+        const columns = await getColumnsByProjectName({
+          context,
+          repoId,
+          projectName: column.project.name,
+        });
+        // issue already has a Zube label, move to matching projects column
+        await moveProjectCard({
+          context,
+          projectCardNode,
+          newColumn: zubeLabel.name,
+          projectColumns: columns,
+        });
+      }
     } else {
       const accessJwt = await getAccessJwt();
       // card created in GitHub, move Zube ticket from triage to matching board & category
@@ -78,9 +82,6 @@ module.exports = async function onCardCreated(context) {
           },
           method: 'PUT',
         });
-
-        // add a label?
-        // Not sure if Zube does this for you
       }
     }
   }

--- a/graphql/project-card.js
+++ b/graphql/project-card.js
@@ -30,14 +30,18 @@ query getIssueFromProjectCard($id: ID!) {
 `;
 
 const GET_PROJECT_CARD_FROM_ISSUE = `
-query getProjectCardFromIssue($issueId: ID!) {
-    node(id: $issueId) {
+query getProjectCardFromIssue($id: ID!) {
+    node(id: $id) {
       id
       ... on Issue {
         number
         projectCards(first: 1) {
          nodes {
             node_id: id
+            project {
+              id
+              name
+            }
          }
        }
      }
@@ -62,8 +66,8 @@ mutation addProjectCard($input: AddProjectCardInput!) {
 `;
 
 const DELETE_PROJECT_CARD = `
-  mutation removeProjectCard($input: DeleteProjectCardInput!) {
-    removeProjectCard(input: $input) {
+  mutation deleteProjectCard($input: DeleteProjectCardInput!) {
+    deleteProjectCard(input: $input) {
       clientMutationId   
     }
   }

--- a/graphql/project.js
+++ b/graphql/project.js
@@ -12,6 +12,8 @@ query getProjectFromIssue($id: ID!) {
             name
           }
           project {
+            id
+            name
             columns(first: 20) {
               nodes {
                 id

--- a/issue-unlabeled.js
+++ b/issue-unlabeled.js
@@ -1,4 +1,6 @@
 const { GET_PROJECT_CARD_FROM_ISSUE, DELETE_PROJECT_CARD } = require('./graphql/project-card');
+const { getZubeCardDetails, addCardToProject, moveProjectCard } = require('./shared');
+const { LABELING_HANDLER_ACTIONS, getLabelingHandlerAction } = require('./label-actions-shared');
 
 module.exports = async function onIssueUnlabeled(context) {
   const { issue, label } = context.payload;
@@ -11,14 +13,39 @@ module.exports = async function onIssueUnlabeled(context) {
     } = await context.github.graphql(GET_PROJECT_CARD_FROM_ISSUE, {
       id: issue.node_id,
     });
+    const { zubeWorkspace, zubeCategory } = await getZubeCardDetails(context);
+    const [projectCardNode] = projectCards;
+    if (projectCardNode) {
+      const { DELETE_CARD, MOVE_CARD_PROJECT, MOVE_CARD_COLUMN } = LABELING_HANDLER_ACTIONS;
 
-    if (projectCards.length) {
-      const [projectCard] = projectCards;
-      await context.github.graphql(DELETE_PROJECT_CARD, {
-        input: {
-          cardId: projectCard.id,
-        },
+      const action = getLabelingHandlerAction({
+        action: context.payload.action,
+        zubeWorkspace,
+        gitHubProject: projectCardNode.project,
+        zubeCategory,
+        gitHubColumn: projectCardNode.column,
       });
+
+      if (action === DELETE_CARD) {
+        await context.github.graphql(DELETE_PROJECT_CARD, {
+          input: {
+            cardId: projectCardNode.node_id,
+          },
+        });
+      }
+
+      if (action === MOVE_CARD_COLUMN) {
+        moveProjectCard({ context, projectCardNode, newColumn: `[zube]: ${zubeCategory.name}` });
+      }
+
+      if (action === MOVE_CARD_PROJECT) {
+        await context.github.graphql(DELETE_PROJECT_CARD, {
+          input: {
+            cardId: projectCardNode.node_id,
+          },
+        });
+        await addCardToProject({ context, zubeWorkspace, zubeCategory });
+      }
     }
   }
 };

--- a/label-actions-shared.js
+++ b/label-actions-shared.js
@@ -1,0 +1,27 @@
+const LABELING_HANDLER_ACTIONS = {
+  DELETE_CARD: 'delete-card',
+  MOVE_CARD_PROJECT: 'move-card-project',
+  MOVE_CARD_COLUMN: 'move-card-column',
+};
+
+function getLabelingHandlerAction({
+  zubeWorkspace, gitHubProject, zubeCategory, gitHubColumn,
+}) {
+  const { DELETE_CARD, MOVE_CARD_PROJECT, MOVE_CARD_COLUMN } = LABELING_HANDLER_ACTIONS;
+  if (!zubeWorkspace) {
+    return DELETE_CARD;
+  }
+  // does that project exist in GitHub?
+  if (zubeWorkspace.name.toLowerCase() !== gitHubProject.name.toLowerCase()) {
+    return MOVE_CARD_PROJECT;
+  }
+
+  if (gitHubColumn && zubeCategory.toLowerCase() !== gitHubColumn.name.toLowerCase()) {
+    return MOVE_CARD_COLUMN;
+  }
+}
+
+module.exports = {
+  LABELING_HANDLER_ACTIONS,
+  getLabelingHandlerAction,
+};

--- a/test/fixtures/github/issue.json
+++ b/test/fixtures/github/issue.json
@@ -10,6 +10,7 @@
                 "name": "In progress"
               },
               "project": {
+                "name": "Team Rocket",
                 "columns": {
                   "nodes": [
                     {


### PR DESCRIPTION
Closes #41 

Also, allows the card to move to a different project when the Zube ticket is assigned to another team board.